### PR TITLE
Bugfix: only execute macro if properly settings['macro'] properly filled

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,12 +23,14 @@ Release notes
 Version 0.9.5
 -------------
 
-In Eskapade-Core v0.9.4 the eskapade_bootstrap method has been severely upgraded.
-Running this command will generate you a new (Eskapade) project directory with 
-a working link, macro, tests, entry-point scripts, and setup.py file!
+In Eskapade-Core v0.9.5:
 
-In addition, escore.eskapade_run() has been made more user-friendly for standalone use 
-with python or jupyter.
+* The eskapade_bootstrap method has been severely upgraded. Running this command will generate you a new (Eskapade) project directory with a working link, macro, tests, entry-point scripts, and setup.py file!
+
+* escore.eskapade_run() has been made more user-friendly for standalone use with python or jupyter.
+
+* added __main__ function to every newly generated macro, so macros can now be run standalone.
+
 
 Version 0.9
 -----------

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Eskapade-Core
 =============
 
-* Version: 0.9.4
+* Version: 0.9.5
 * Released: Dec 2018
 
 Eskapade is a light-weight, python-based data analysis framework, meant for modularizing all sorts of data analysis problems
@@ -20,12 +20,15 @@ For the minimal documentation on Eskapade-Core, please go `here <http://eskapade
 Release notes
 =============
 
-Version 0.9.4
+Version 0.9.5
 -------------
 
 In Eskapade-Core v0.9.4 the eskapade_bootstrap method has been severely upgraded.
 Running this command will generate you a new (Eskapade) project directory with 
 a working link, macro, tests, entry-point scripts, and setup.py file!
+
+In addition, escore.eskapade_run() has been made more user-friendly for standalone use 
+with python or jupyter.
 
 Version 0.9
 -----------

--- a/python/escore/_bootstrap.py
+++ b/python/escore/_bootstrap.py
@@ -307,6 +307,11 @@ link.logger.log_level = LogLevel.DEBUG
 ch.add(link)
 
 logger.debug('Done parsing configuration file {macro_name!s}.')
+
+
+if __name__ == "__main__":
+    import escore
+    escore.eskapade_run()
 """
 
     content = template.format(macro_name=macro_name,

--- a/python/escore/core/execution.py
+++ b/python/escore/core/execution.py
@@ -72,7 +72,7 @@ def eskapade_configure(settings=None):
         escore.utils.set_matplotlib_backend(batch=True, silent=False)
 
     # execute configuration macro, this sets up the order of the chains and links.
-    if 'macro' in settings:
+    if settings.get('macro'):
         process_manager.execute_macro(settings['macro'])
 
 

--- a/python/escore/logger/_logging.py
+++ b/python/escore/logger/_logging.py
@@ -109,7 +109,15 @@ class LogPublisher(logging.getLoggerClass()):
 
         :param handler: The log record handler.
         """
-        self.addHandler(handler)
+        # make sure we do not add duplicate handlers
+        handler_exists = False
+        if len(self.handlers) > 0:
+            for hdlr in self.handlers:
+                if isinstance(handler, type(hdlr)):
+                    handler_exists = True
+                    break
+        if not handler_exists:
+            self.addHandler(handler)
 
     def remove_handler(self, handler: logging.StreamHandler):
         """Remove a log record handler.
@@ -154,9 +162,6 @@ class LogPublisher(logging.getLoggerClass()):
 # Set LogPublisher to be the logger class.
 logging.setLoggerClass(LogPublisher)
 
-# The global application publisher. There should be only one.
-global_log_publisher = logging.getLogger('eskapade')
-
 
 # Handlers
 class ConsoleHandler(logging.StreamHandler):
@@ -179,6 +184,15 @@ class ConsoleErrHandler(logging.StreamHandler):
         """Initialize the ConsoleHandler object."""
         super().__init__(sys.stderr)
         self.setLevel(LogLevel.ERROR)
+
+
+# The global application publisher. There should be only one.
+global_log_publisher = logging.getLogger('eskapade')
+# initialize to info. can be overwritten later.
+global_log_publisher.log_level = LogLevel.INFO
+# publisher takes care that same handler is never added twice
+global_log_publisher.add_handler(ConsoleHandler())
+global_log_publisher.add_handler(ConsoleErrHandler())
 
 
 class Logger(object):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ NAME = 'Eskapade-Core'
 
 MAJOR = 0
 REVISION = 9
-PATCH = 4
+PATCH = 5
 DEV = False
 
 # NOTE: also update version at: README.rst


### PR DESCRIPTION
B/c by default: settings['macro'] = None, this is now correctly not executed.

(I've been trying to make eskapade_run() to be more friendly in python and jupyter.)