### PR TITLE
Several small updates to make eskapade friendlier in python or jupyter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Eskapade-Core
 =============
 
-* Version: 0.9.4
-* Released: Dec 2018
+* Version: 1.0.0
+* Released: Jan 2018
 
 Eskapade is a light-weight, python-based data analysis framework, meant for modularizing all sorts of data analysis problems
 into reusable analysis components. 
@@ -20,12 +20,27 @@ For the minimal documentation on Eskapade-Core, please go `here <http://eskapade
 Release notes
 =============
 
-Version 0.9.4
+Version 1.0.0
 -------------
 
-In Eskapade-Core v0.9.4 the eskapade_bootstrap method has been severely upgraded.
-Running this command will generate you a new (Eskapade) project directory with 
-a working link, macro, tests, entry-point scripts, and setup.py file!
+In Eskapade-Core v1.0.0:
+
+* Eskapade goes parallel. The execution of chains can be forked, so chains can run in parallel! See tutorial esk112 for details.
+
+* The eskapade_bootstrap method has been severely upgraded. Running this command will generate you a new (Eskapade) project directory with a working link, macro, tests, entry-point scripts, and setup.py file!
+
+* escore.eskapade_run() has been made more user-friendly for standalone use with python or jupyter.
+
+* added __main__ function to every newly generated macro, so macros can now be run standalone. In addition, eskapade_generate_macro now makes a python function in the macro.
+
+* The Eskapade DbConnection base class has been migraged to core.
+
+* The DataStore now has a fancy get() function that can assert the type, length, and presence of object.
+
+* Added a new link ``ApplyFunc`` that applies function to objects in the datastore. Simple but very useful.
+
+* Plus several small updates to existing links in core_ops: ``skip_chain_if_empty``, ``import_data_store``, ``BreakLink``. 
+
 
 Version 0.9
 -----------

--- a/python/escore/__init__.py
+++ b/python/escore/__init__.py
@@ -2,6 +2,7 @@
 from escore.core.definitions import StatusCode
 from escore.core.process_services import ConfigObject
 from escore.core.process_services import DataStore
+from escore.core.process_services import ForkStore
 from escore.core.element import Chain, Link
 from escore.core.process_manager import process_manager
 from escore.core.execution import eskapade_run

--- a/python/escore/_bootstrap.py
+++ b/python/escore/_bootstrap.py
@@ -121,7 +121,7 @@ class {link_name!s}(Link):
 
         # Process and register keyword arguments. If the arguments are not given, all arguments are popped from
         # kwargs and added as attributes of the link. Otherwise, only the provided arguments are processed.
-        self._process_kwargs(kwargs, read_key=None, store_key=None)
+        self._process_kwargs(kwargs, read_key='', store_key='')
 
         # check residual kwargs; exit if any present
         self.check_extra_kwargs(kwargs)
@@ -134,6 +134,17 @@ class {link_name!s}(Link):
         :returns: status code of initialization
         :rtype: StatusCode
         \"\"\"
+        # check input arguments. both read_key and store_key need to be a string
+        self.check_arg_types(read_key=str, store_key=str)
+
+        # the attribute 'keys' (missing in this example) needs to be a list.
+        #self.check_arg_types(keys=list)
+        # the items of keys need to be strings. None is allowed as well.
+        #self.check_arg_types(recurse=True, allow_none=True, keys=str)
+
+        # both read_key and store_key need to be filled.
+        #self.check_arg_vals('read_key', 'store_key')
+
         return StatusCode.Success
 
     def execute(self):
@@ -147,6 +158,13 @@ class {link_name!s}(Link):
 
         # --- your algorithm code goes here
         self.logger.debug('Now executing link: {{link}}.', link=self.name)
+
+        # --- example where obj is retrieved from the datastore, with several requirements:
+        #     1) key is present in the datastore, 2) obj needs to have type list or tuple, 3) obj is required to have non-zero length.
+        #obj = ds.get(self.read_key, assert_in=True, assert_type=(list, tuple), assert_len=True)
+
+        # --- storage back into the datastore
+        #ds[self.store_key] = obj
 
         return StatusCode.Success
 
@@ -570,7 +588,7 @@ TEST_REQUIREMENTS = ['pytest>=3.5.0',
                      'pytest-pylint>=0.9.0',
                      ]
 REQUIREMENTS = [
-    'Eskapade-Core>=0.9.3'
+    'Eskapade-Core>=1.0.0'
     ]
 
 REQUIREMENTS = REQUIREMENTS + TEST_REQUIREMENTS

--- a/python/escore/_bootstrap.py
+++ b/python/escore/_bootstrap.py
@@ -286,28 +286,34 @@ modification, are permitted according to the terms listed in the file
 LICENSE.
 \"\"\"
 
-from escore import process_manager, Chain, ConfigObject, core_ops
-from escore.logger import Logger, LogLevel
-{import_line!s}
+def configure():
+    \"\"\" {macro_name!s}: set up links and chains
+    \"\"\"
+    from escore import process_manager, Chain, ConfigObject, core_ops
+    from escore.logger import Logger, LogLevel
+    {import_line!s}
 
-logger = Logger()
-logger.debug('Now parsing configuration file {macro_name!s}.')
+    logger = Logger()
+    logger.debug('Now parsing configuration file {macro_name!s}.')
 
-# --- minimal analysis information
+    # --- minimal analysis information
+    settings = process_manager.service(ConfigObject)
+    settings['analysisName'] = '{macro_name!s}'
+    settings['version'] = 0
 
-settings = process_manager.service(ConfigObject)
-settings['analysisName'] = '{macro_name!s}'
-settings['version'] = 0
+    # --- now set up the chains and links
+    ch = Chain('Start')
+    link = {link_module!s}.{link_name!s}()
+    link.logger.log_level = LogLevel.DEBUG
+    ch.add(link)
 
-# --- now set up the chains and links
+    logger.debug('Done parsing configuration file {macro_name!s}.')
 
-ch = Chain('Start')
-link = {link_module!s}.{link_name!s}()
-link.logger.log_level = LogLevel.DEBUG
-ch.add(link)
 
-logger.debug('Done parsing configuration file {macro_name!s}.')
-
+if __name__ in ["__main__", "escore.core.process_manager"]:
+    # --- set up the links and chains, executed by: python main(), or by
+    #     process_manager.execute_macro() when passing this config-file to eskapade_run script
+    configure()
 
 if __name__ == "__main__":
     import escore

--- a/python/escore/_bootstrap.py
+++ b/python/escore/_bootstrap.py
@@ -307,6 +307,11 @@ link.logger.log_level = LogLevel.DEBUG
 ch.add(link)
 
 logger.debug('Done parsing configuration file {macro_name!s}.')
+
+
+if __name__ == "__main__":
+    import escore
+    escore.eskapade_run()
 """
 
     content = template.format(macro_name=macro_name,

--- a/python/escore/core/dbconnection.py
+++ b/python/escore/core/dbconnection.py
@@ -1,0 +1,69 @@
+"""Project: Eskapade - A python-based package for data analysis.
+
+Created: 2017/03/31
+
+Description:
+    Eskapade DBConnection class
+    The base class for handling database connections with Eskapade's ProcessService
+
+Authors:
+    KPMG Advanced Analytics & Big Data team, Amstelveen, The Netherlands
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted according to the terms listed in the file
+LICENSE.
+"""
+
+from escore.core.mixin import ConfigMixin
+from escore.core.process_services import ProcessService
+
+class DbConnection(ProcessService, ConfigMixin):
+    """Base class for database connections"""
+
+    _persist = False
+
+    def __init__(self, config_path='', config_section=''):
+        """Initialize database connection instance"""
+
+        self._conn = None
+        self._config_section = str(config_section) if config_section else ''
+        ConfigMixin.__init__(self, config_path=config_path)
+
+    @property
+    def connection(self):
+        """Underlying database connection"""
+
+        if not self._conn:
+            self.create_connection()
+        return self._conn
+
+    def create_connection(self):
+        """Create the underlying database connection"""
+        pass
+
+    @property
+    def config_section(self):
+        """Section in configuration settings"""
+
+        return self._config_section
+
+    @config_section.setter
+    def config_section(self, sec):
+        """Set section in configuration settings"""
+
+        sec = str(sec) if sec else ''
+        if not sec:
+            self.logger.fatal('No configuration section specified for {type}.', type=type(self).__name__)
+            raise ValueError('No value specified for configuration section.')
+        self._config_section = sec
+
+    def close(self):
+        """Close database connection"""
+        pass
+
+    def finish(self):
+        """Finish database operations"""
+
+        if self._conn:
+            self.close()
+        self._conn = None

--- a/python/escore/core/element.py
+++ b/python/escore/core/element.py
@@ -302,6 +302,7 @@ class Chain(Processor, ProcessorSequence, TimerMixin):
 
         self.prev_chain_name = ''  # type: str
         self.enabled = True  # type: bool
+        self.n_fork = 0
 
         # We register ourselves with the process manager.
         # If none is specified register with the default
@@ -331,7 +332,7 @@ class Chain(Processor, ProcessorSequence, TimerMixin):
                 break
             # A link may request to skip the rest of the execution of the chain (but do perform finalize).
             elif status == StatusCode.BreakChain:
-                self.logger.warning('Breaking of exection of chain "{chain!s} as requested by link "{link!s}"!',
+                self.logger.warning('Breaking off execution of chain "{chain!s} as requested by link "{link!s}"!',
                                     chain=self, link=_)
                 break
             # A link may request that the chain needs to be repeated during execution, e.g.

--- a/python/escore/core/execution.py
+++ b/python/escore/core/execution.py
@@ -72,7 +72,7 @@ def eskapade_configure(settings=None):
         escore.utils.set_matplotlib_backend(batch=True, silent=False)
 
     # execute configuration macro, this sets up the order of the chains and links.
-    if 'macro' in settings:
+    if settings.get('macro'):
         process_manager.execute_macro(settings['macro'])
 
 

--- a/python/escore/core/process_manager.py
+++ b/python/escore/core/process_manager.py
@@ -617,7 +617,7 @@ class ProcessManager(Processor, ProcessorSequence, TimerMixin):
 
         # Finalize
         if status == StatusCode.Success:
-            status = process_manager.finalize()
+            status = self.finalize()
             # Profiling output
             if profiler:
                 import io

--- a/python/escore/core/process_services.py
+++ b/python/escore/core/process_services.py
@@ -407,6 +407,37 @@ class DataStore(ProcessService, dict):
 
     _persist = True
 
+    def get(self, key: str, default: Any = None, assert_type: Any = None, assert_len: bool = False, assert_in: bool = False) -> object:
+        """Get value of setting. If it does not exists return the default value.
+
+        :param key: The key of object to get.
+        :param default: The default value of the key in case not found.
+        :param assert_type: if set, check object for given type or tuple of types. If fails, raise TypeError.
+        :param assert_len: if true, check that object has length greater than 0. If fails, raise TypeError or AssertionError.
+        :param assert_in: if true, assert that key is known.
+
+        :return: The value of the key or None if it does not exist.
+        """
+        try:
+            obj = self.__getitem__(key)
+        except Exception as e: #KeyError:
+            # key not found in datastore
+            if assert_in:
+                raise e
+            obj = default
+        if assert_type is not None:
+            if not isinstance(obj, assert_type):
+                raise TypeError('object with key {key} not of type(s): {types}'.format(key=key, types=assert_type))
+        if assert_len:
+            try:
+                obj_length = len(obj)
+                if obj_length == 0:
+                    raise AssertionError('object with key {key} has zero length'.format(key=key))
+            except Exception as e: #TypeError:
+                # object has no len() function
+                raise e
+        return obj
+
     def Print(self):
         """Print a summary the data store contents."""
         self.logger.info('Summary of data store ({n:d} objects)', n=len(self))

--- a/python/escore/core_ops/links/__init__.py
+++ b/python/escore/core_ops/links/__init__.py
@@ -14,6 +14,7 @@ from escore.core_ops.links.apply import DsApply
 from escore.core_ops.links.import_data_store import ImportDataStore
 from escore.core_ops.links.fork_example import ForkExample
 from escore.core_ops.links.fork_data_collector import ForkDataCollector
+from escore.core_ops.links.apply_func import ApplyFunc
 
 __all__ = ['AssertInDs',
            'Break',
@@ -30,4 +31,5 @@ __all__ = ['AssertInDs',
            'DsApply',
            'ImportDataStore',
            'ForkExample',
-           'ForkDataCollector']
+           'ForkDataCollector',
+           'ApplyFunc']

--- a/python/escore/core_ops/links/__init__.py
+++ b/python/escore/core_ops/links/__init__.py
@@ -12,6 +12,8 @@ from escore.core_ops.links.skip_chain_if_empty import SkipChainIfEmpty
 from escore.core_ops.links.to_ds_dict import ToDsDict
 from escore.core_ops.links.apply import DsApply
 from escore.core_ops.links.import_data_store import ImportDataStore
+from escore.core_ops.links.fork_example import ForkExample
+from escore.core_ops.links.fork_data_collector import ForkDataCollector
 
 __all__ = ['AssertInDs',
            'Break',
@@ -26,4 +28,6 @@ __all__ = ['AssertInDs',
            'SkipChainIfEmpty',
            'ToDsDict',
            'DsApply',
-           'ImportDataStore']
+           'ImportDataStore',
+           'ForkExample',
+           'ForkDataCollector']

--- a/python/escore/core_ops/links/__init__.py
+++ b/python/escore/core_ops/links/__init__.py
@@ -15,6 +15,7 @@ from escore.core_ops.links.import_data_store import ImportDataStore
 from escore.core_ops.links.fork_example import ForkExample
 from escore.core_ops.links.fork_data_collector import ForkDataCollector
 from escore.core_ops.links.apply_func import ApplyFunc
+from escore.core_ops.links.skip_chain_if_present import SkipChainIfPresent
 
 __all__ = ['AssertInDs',
            'Break',
@@ -32,4 +33,5 @@ __all__ = ['AssertInDs',
            'ImportDataStore',
            'ForkExample',
            'ForkDataCollector',
-           'ApplyFunc']
+           'ApplyFunc',
+           'SkipChainIfPresent']

--- a/python/escore/core_ops/links/apply_func.py
+++ b/python/escore/core_ops/links/apply_func.py
@@ -1,0 +1,87 @@
+"""Project: Eskapade - A python-based package for data analysis.
+
+Class: ApplyFunc
+
+Created: 2018-12-29
+
+Description:
+    Algorithm that applies a function to an object in the datastore
+
+Authors:
+    KPMG Advanced Analytics & Big Data team, Amstelveen, The Netherlands
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted according to the terms listed in the file
+LICENSE.
+"""
+
+from escore import process_manager, ConfigObject, DataStore, Link, StatusCode
+import copy
+
+class ApplyFunc(Link):
+
+    """Algorithm that applies a function to an object in the datastore."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize an instance.
+
+        :param str name: name of link
+        :param str read_key: key of input data to read from data store
+        :param str store_key: key of output data to store in data store
+        :param func: function to execute
+        :param args: all args are passed pass to function as args.
+        :param kwargs: all other key word arguments are passed on to the function as kwargs.
+        """
+        # initialize Link, pass name from kwargs
+        Link.__init__(self, kwargs.pop('name', 'ApplyFunc'))
+
+        # Process and register keyword arguments. If the arguments are not given, all arguments are popped from
+        # kwargs and added as attributes of the link. Otherwise, only the provided arguments are processed.
+        self._process_kwargs(kwargs, read_key='', store_key='', func=None)
+
+        # pass on remaining kwargs to pandas reader
+        self.args = copy.deepcopy(args)
+        self.kwargs = copy.deepcopy(kwargs)
+
+    def initialize(self):
+        """Initialize the link.
+
+        :returns: status code of initialization
+        :rtype: StatusCode
+        """
+        if not isinstance(self.read_key, (str, list)):
+            raise AssertionError('read_key should be a string or list of strings.')
+        self.check_arg_types(store_key=str)
+        if self.func is None:
+            raise AssertionError('Input function not set correctly.')
+
+        return StatusCode.Success
+
+    def execute(self):
+        """Execute the link.
+
+        :returns: status code of execution
+        :rtype: StatusCode
+        """
+        ds = process_manager.service(DataStore)
+
+        if self.read_key:
+            # fetch and check input
+            if isinstance(self.read_key, str):
+                obj = ds.get(self.read_key, None)
+                if obj is None:
+                    raise RuntimeError('object {} not found in datastore'.format(self.read_key))
+            elif isinstance(self.read_key, list):
+                obj = [ds.get(key, None) for key in self.read_key]
+                if any(o is None for o in obj):
+                    raise RuntimeError('any of objects {} not found in datastore'.format(self.read_key))
+            # apply function
+            trans_obj = self.func(obj, *self.args, **self.kwargs)
+        else:
+            # possibly function does not require object as input
+            trans_obj = self.func(*self.args, **self.kwargs)
+
+        if self.store_key:
+            ds[self.store_key] = trans_obj
+
+        return StatusCode.Success

--- a/python/escore/core_ops/links/apply_func.py
+++ b/python/escore/core_ops/links/apply_func.py
@@ -27,17 +27,28 @@ class ApplyFunc(Link):
 
         :param str name: name of link
         :param str read_key: key of input data to read from data store
-        :param str store_key: key of output data to store in data store
+        :param default: The default value of the key in case not found.
+        :param assert_type: if set, check object for given type or tuple of types. If fails, raise TypeError.
+        :param bool assert_len: if true, check that object has length greater than 0. If fails, raise TypeError or AssertionError.
+        :param bool assert_in: assert that key is known, default is true.
         :param func: function to execute
         :param args: all args are passed pass to function as args.
         :param kwargs: all other key word arguments are passed on to the function as kwargs.
+        :param str store_key: key of output data to store in data store
         """
         # initialize Link, pass name from kwargs
         Link.__init__(self, kwargs.pop('name', 'ApplyFunc'))
 
         # Process and register keyword arguments. If the arguments are not given, all arguments are popped from
         # kwargs and added as attributes of the link. Otherwise, only the provided arguments are processed.
-        self._process_kwargs(kwargs, read_key='', store_key='', func=None)
+        self._process_kwargs(kwargs,
+                             read_key = '',
+                             default = None,
+                             assert_type = None,
+                             assert_len = False,
+                             assert_in = True,
+                             func = None,
+                             store_key='')
 
         # pass on remaining kwargs to pandas reader
         self.args = copy.deepcopy(args)
@@ -50,10 +61,10 @@ class ApplyFunc(Link):
         :rtype: StatusCode
         """
         if not isinstance(self.read_key, (str, list)):
-            raise AssertionError('read_key should be a string or list of strings.')
+            raise TypeError('read_key should be a string or list of strings.')
         self.check_arg_types(store_key=str)
         if self.func is None:
-            raise AssertionError('Input function not set correctly.')
+            raise AssertionError('Input function not set.')
 
         return StatusCode.Success
 
@@ -68,13 +79,9 @@ class ApplyFunc(Link):
         if self.read_key:
             # fetch and check input
             if isinstance(self.read_key, str):
-                obj = ds.get(self.read_key, None)
-                if obj is None:
-                    raise RuntimeError('object {} not found in datastore'.format(self.read_key))
+                obj = ds.get(self.read_key, self.default, self.assert_type, self.assert_len, self.assert_in)
             elif isinstance(self.read_key, list):
-                obj = [ds.get(key, None) for key in self.read_key]
-                if any(o is None for o in obj):
-                    raise RuntimeError('any of objects {} not found in datastore'.format(self.read_key))
+                obj = [ds.get(key, self.default, self.assert_type, self.assert_len, self.assert_in) for key in self.read_key]
             # apply function
             trans_obj = self.func(obj, *self.args, **self.kwargs)
         else:

--- a/python/escore/core_ops/links/break_link.py
+++ b/python/escore/core_ops/links/break_link.py
@@ -31,15 +31,20 @@ class Break(Link):
         """Initialize link instance.
 
         :param str name: name of link
+        :param bool send_break: if true, send StatusCode.BreakChain (skip execution of rest of chain).
+                                Default is false, then sends StatusCode.Failure (exit program).
         """
         # initialize Link, pass name from kwargs
         Link.__init__(self, kwargs.pop('name', 'Break'))
+        self._process_kwargs(kwargs, send_break=False)
 
         # check residual kwargs. exit if any present
         self.check_extra_kwargs(kwargs)
 
     def execute(self):
         """Execute the link."""
+        if self.send_break:
+            return StatusCode.BreakChain
         # halt the execution of process_manager by sending a failure signal
         self.logger.info('Now sending break signal to halt execution!')
         return StatusCode.Failure

--- a/python/escore/core_ops/links/fork_data_collector.py
+++ b/python/escore/core_ops/links/fork_data_collector.py
@@ -1,0 +1,160 @@
+"""Project: Eskapade - A python-based package for data analysis.
+
+Class: ForkDataCollector
+
+Created: 2018-12-26
+
+Description:
+    Algorithm to collect and merge objects from the datastore during a fork.
+
+Authors:
+    KPMG Advanced Analytics & Big Data team, Amstelveen, The Netherlands
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted according to the terms listed in the file
+LICENSE.
+"""
+
+from escore import process_manager, ConfigObject, DataStore, ForkStore, Link, StatusCode
+
+def unit_func(x):
+    return x
+
+class ForkDataCollector(Link):
+
+    """Defines the content of link."""
+
+    def __init__(self, **kwargs):
+        """Initialize an instance.
+
+        :param str name: name of link
+        :param list keys: functions to apply (list of dicts)
+          - 'key_ds' (string): input key in datastore
+          - 'key_fs' (string, optional): output key in forkstore
+          - 'func': function to apply, optional
+          - 'append': if key_ds points to a list, append each item to list in forkstore. Default is True.
+          - 'args' (tuple, optional): args for 'func'
+          - 'kwargs' (dict, optional): kwargs for 'func'
+        """
+        # initialize Link, pass name from kwargs
+        Link.__init__(self, kwargs.pop('name', 'ForkDataCollector'))
+
+        # Process and register keyword arguments. If the arguments are not given, all arguments are popped from
+        # kwargs and added as attributes of the link. Otherwise, only the provided arguments are processed.
+        self._process_kwargs(kwargs, keys=[])
+
+        # check residual kwargs; exit if any present
+        self.check_extra_kwargs(kwargs)
+        # Turn off the line above, and on the line below if you wish to keep these extra kwargs.
+        # self._process_kwargs(kwargs)
+
+    def initialize(self):
+        """Initialize the link.
+
+        :returns: status code of initialization
+        :rtype: StatusCode
+        """
+        if not self.keys:
+            self.logger.warning('No functions to apply')
+
+        # perform basic checks on input keys
+        for idx in range(len(self.keys)):
+            if isinstance(self.keys[idx], str):
+                arr = self.keys[idx]
+                arr = dict(key_fs=arr, key_ds=arr, func=unit_func)
+                self.keys[idx] = arr
+            if not isinstance(self.keys[idx], dict):
+                raise AssertionError('keys attribute is not a list of dict/str.')
+            arr = self.keys[idx]
+            keys = list(arr.keys())
+            if 'key_ds' not in keys:
+                raise AssertionError('key input is insufficient.')
+
+        # will count number of times execute has been called.
+        fs = process_manager.service(ForkStore)
+        fs['n_'+self.name+'_executed'] = 0
+
+        return StatusCode.Success
+
+    def execute(self):
+        """Execute the link.
+
+        :returns: status code of execution
+        :rtype: StatusCode
+        """
+        settings = process_manager.service(ConfigObject)
+        if not 'fork' in settings:
+            # nothing to do
+            return StatusCode.Success
+        fidx = settings.get('fork_index', 0)
+
+        ds = process_manager.service(DataStore)
+        fs = process_manager.service(ForkStore)
+
+        # collecting inputs from datastore and adding to forkstore
+        for arr in self.keys:
+            keys = list(arr.keys())
+            key_ds = arr['key_ds']
+            assert key_ds in ds, 'key {} not in datastore'.format(key_ds)
+            key_fs = key_ds if 'key_fs' not in keys else arr['key_fs']
+            append_items = True if 'append' not in keys else arr['append']
+            # make sure forkstore is unlocked, then lock
+            #fs.wait_until_unlocked()
+            with fs.lock:
+                fs['n_'+self.name+'_executed'] += 1
+                #EOFError: Ran out of input
+                #_pickle.UnpicklingError: invalid load key, '\x00'.
+                # make sure of order
+                temp_list = fs.get(key_fs, [])
+                obj = ds[key_ds]
+                if not isinstance(obj, list):
+                    temp_list.append(obj)
+                else:
+                    if append_items:
+                        temp_list += obj
+                    else:
+                        temp_list.append(obj)
+                fs[key_fs] = temp_list
+
+        return StatusCode.Success
+
+    def finalize(self):
+        """Finalize the link.
+
+        :returns: status code of finalization
+        :rtype: StatusCode
+        """
+        ds = process_manager.service(DataStore)
+        fs = process_manager.service(ForkStore)
+
+        # check if nothing to do
+        if fs.get('n_'+self.name+'_executed', 0) == 0:
+            return StatusCode.Success
+        # check number of times forkdatacollector has run
+        if fs.get('n_fork', 0) > 0 and (fs['n_'+self.name+'_executed'] % fs['n_fork'] > 0):
+            self.logger.warning('Did not execute multiple of n_fork {0} times: {1}. Data may be missing.'.format(fs['n_fork'], fs['n_'+self.name+'_executed']))
+
+        # putting (transformed) objects from forkstore back into datastore
+        for arr in self.keys:
+            keys = list(arr.keys())
+            key_ds = arr['key_ds']
+            key_fs = key_ds if 'key_fs' not in keys else arr['key_fs']
+            if key_fs not in fs:
+                raise AssertionError('key {} not in forkstore.'.format(key_fs))
+            # retrieve function to apply
+            func = unit_func if 'func' not in keys else arr['func']
+            args = () if 'args' not in keys else arr['args']
+            kwargs = {} if 'kwargs' not in keys else arr['kwargs']
+            # apply transformation
+            self.logger.debug('Applying function {function!s}.', function=func)
+            obj = fs[key_fs]
+            try:
+                trans_obj = func(obj, *args, **kwargs)
+            except:
+                raise Exception('Failed to apply function {function!s} to object with {key}.', function=func, key=key_ds)
+            # put transformed ojbect back in datastore
+            ds[key_ds] = trans_obj
+
+        fs.Print()
+
+        return StatusCode.Success

--- a/python/escore/core_ops/links/fork_example.py
+++ b/python/escore/core_ops/links/fork_example.py
@@ -1,0 +1,100 @@
+"""Project: Eskapade - A python-based package for data analysis.
+
+Class: ForkExample
+
+Created: 2018-12-26
+
+Description:
+    Algorithm to illustrate to how retrieve information of a forked process
+
+Authors:
+    KPMG Advanced Analytics & Big Data team, Amstelveen, The Netherlands
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted according to the terms listed in the file
+LICENSE.
+"""
+
+from escore import process_manager, ConfigObject, DataStore, ForkStore, Link, StatusCode
+
+
+class ForkExample(Link):
+
+    """Defines the content of link."""
+
+    def __init__(self, **kwargs):
+        """Initialize an instance.
+
+        :param str name: name of link
+        :param str store_key: key of object to store in data store
+        """
+        # initialize Link, pass name from kwargs
+        Link.__init__(self, kwargs.pop('name', 'ForkExample'))
+
+        # Process and register keyword arguments. If the arguments are not given, all arguments are popped from
+        # kwargs and added as attributes of the link. Otherwise, only the provided arguments are processed.
+        self._process_kwargs(kwargs, store_key='forkdatacollector')
+
+        # check residual kwargs; exit if any present
+        self.check_extra_kwargs(kwargs)
+        # Turn off the line above, and on the line below if you wish to keep these extra kwargs.
+        # self._process_kwargs(kwargs)
+
+    def initialize(self):
+        """Initialize the link.
+
+        :returns: status code of initialization
+        :rtype: StatusCode
+        """
+        # counter how often this link has been executed.
+        fs = process_manager.service(ForkStore)
+        fs['n_'+self.name+'_executed'] = 0
+
+        return StatusCode.Success
+
+    def execute(self):
+        """Execute the link.
+
+        :returns: status code of execution
+        :rtype: StatusCode
+        """
+        settings = process_manager.service(ConfigObject)
+        if not 'fork' in settings:
+            return StatusCode.Success
+        # this is a forked process!
+
+        ds = process_manager.service(DataStore)
+        fs = process_manager.service(ForkStore)
+
+        # retrieve the index of the forked process
+        fidx = settings.get('fork_index', 0)
+        self.logger.debug('Now executing link: {link}. Fork index: {fidx}', link=self.name, fidx=fidx)
+
+        # store a number for later collection
+        ds[self.store_key] = fidx
+
+        # count how often this loop has been executed (including loops!).
+        # make sure forkstore is unlocked, then lock
+        #fs.wait_until_unlocked()
+        with fs.lock:
+            self.logger.info('Fork {} is locked.'.format(fidx))
+            fs['n_'+self.name+'_executed'] += 1
+        self.logger.info('Fork {} is unlocked.'.format(fidx))
+
+        # fs['exec_index'] += 1 is not stable for some reason?
+        # https://stackoverflow.com/questions/38703907/modify-a-list-in-multiprocessing-pools-manager-dict
+
+        self.logger.debug('Done executing link: {link}. Fork index: {fidx}', link=self.name, fidx=fidx)
+
+        return StatusCode.Success
+
+    def finalize(self):
+        """Finalized the link.
+
+        :returns: status code of finalize
+        :rtype: StatusCode
+        """
+        fs = process_manager.service(ForkStore)
+        self.logger.info('Link {link} has been executed {loop} times.', link=self.name, loop=fs['n_'+self.name+'_executed'])
+
+        return StatusCode.Success

--- a/python/escore/core_ops/links/import_data_store.py
+++ b/python/escore/core_ops/links/import_data_store.py
@@ -31,6 +31,7 @@ class ImportDataStore(Link):
 
         :param str name: name of link
         :param str path: path of the datastore pickle file to import
+        :param bool update: if true update the existing datastore, don't replace it. Default is false.
         :param bool import_at_initialize: if false, perform datastore import at execute. Default is true, at initialize. 
         """
         # initialize Link, pass name from kwargs
@@ -38,7 +39,7 @@ class ImportDataStore(Link):
 
         # Process and register keyword arguments. If the arguments are not given, all arguments are popped from
         # kwargs and added as attributes of the link. Otherwise, only the provided arguments are processed.
-        self._process_kwargs(kwargs, path='', import_at_initialize=True)
+        self._process_kwargs(kwargs, path='', update=False, import_at_initialize=True)
 
         # check residual kwargs; exit if any present
         self.check_extra_kwargs(kwargs)
@@ -69,10 +70,15 @@ class ImportDataStore(Link):
         if not isinstance(ext_store, DataStore):
             self.logger.fatal('Object in file "{path}" not of type DataStore.', path=self.path)
             raise AssertionError('Input object not of type DataStore.')
-        # overwriting existing datastore
-        ds = process_manager.service(DataStore)
-        ds.clear()
-        ds.update(ext_store)
+
+        if self.update:
+            # update existing datastore
+            ds = process_manager.service(DataStore)
+            ds.update(ext_store)
+        else: # default
+            # replace existing datastore
+            process_manager.remove_service(DataStore)
+            process_manager.service(ext_store)
 
     def execute(self):
         """Execute the link.

--- a/python/escore/core_ops/links/skip_chain_if_empty.py
+++ b/python/escore/core_ops/links/skip_chain_if_empty.py
@@ -31,17 +31,16 @@ class SkipChainIfEmpty(Link):
         :param str name: name of link
         :param list collection_set: datastore keys holding the datasets to be checked. If any of these is empty,
                                     the chain is skipped.
-        :param bool skip_chain_when_key_not_in_ds: skip the chain as well if the dataframe is not present in the
-                                                   datastore. When True and if type is 'pandas.DataFrame', sends
-                                                   a SkipChain signal if key not in DataStore
+        :param bool skip_missing: skip the chain if the dataframe is not present in the
+                                  datastore. Default is True.
+        :param bool skip_zero_len: skip the chain if the object is found in the datastore but has zero length. Default is True.
         :param bool check_at_initialize: perform dataset empty is check at initialize. Default is true.
-        :param bool check_at_execute: perform dataset empty is check at initialize. Default is false.
         """
         Link.__init__(self, kwargs.pop('name', 'SkipChainIfEmpty'))
 
         # process keyword arguments
-        self._process_kwargs(kwargs, collection_set=[], skip_chain_when_key_not_in_ds=False, check_at_initialize=True,
-                             check_at_execute=False)
+        self._process_kwargs(kwargs, collection_set=[], skip_missing=True, skip_zero_len=True,
+                             check_at_initialize=True, check_at_execute=False)
         self.check_extra_kwargs(kwargs)
 
     def initialize(self):
@@ -56,33 +55,40 @@ class SkipChainIfEmpty(Link):
 
         Skip to the next Chain if any of the input dataset is empty.
         """
-        if self.check_at_execute:
+        if not self.check_at_initialize or self.check_at_execute:
             return self.check_collection_set()
 
         return StatusCode.Success
 
     def check_collection_set(self):
-        """Check existence of collection in either mongo or datastore, and check that they are not empty.
+        """Check existence of collection in the datastore, and check if they are empty.
 
-        Collections need to be both present and not empty.
-
-        - For mongo collections a dedicated filter can be applied before doing the count.
-        - For pandas dataframes the additional option 'skip_chain_when_key_not_in_ds' exists. Meaning,
-          skip the chain as well if the dataframe is not present in the datastore.
+        All collections need to be both present and not empty for the chain to be continued.
         """
-        # check if collection names are present in datastore
         ds = process_manager.service(DataStore)
+
+        # check if requested collection names are present in datastore
+        # if anyone is missing, skip the chain
         for k in self.collection_set:
             if k not in ds:
-                if self.skip_chain_when_key_not_in_ds:
-                    self.logger.warning('Key {key!s} not in DataStore. Sending skip chain signal.', key=k)
+                if self.skip_missing: # default is true
+                    self.logger.info('Key {key!s} not in DataStore. Skipping chain as requested.', key=k)
                     return StatusCode.SkipChain
                 else:
-                    raise Exception('Key "{key}" not in DataStore.'.format(key=k))
-            df = ds[k]
-            if len(df.index) == 0:
-                self.logger.warning(
-                    'pandas.DataFrame with datastore key "{key!s}" is empty. Sending skip chain signal.', key=k)
-                return StatusCode.SkipChain
+                    self.logger.warning('Key {key!s} not in DataStore. Continuing nonetheless.', key=k)
+                    continue
+            obj = ds[k]
+            if self.skip_zero_len: # default is true
+                try:
+                    obj_length = len(obj)
+                    if obj_length == 0:
+                        self.logger.info('object with key {key} has zero length. Skipping chain as requested.', key=k)
+                        return StatusCode.SkipChain
+                    else:
+                        self.logger.debug('object with key {key} has length {n}. Continuing.', key=k, n=obj_length)
+                        continue
+                except Exception as e: #TypeError:
+                    self.logger.error('object with key {key} has no len() function.', key=k)
+                    raise e
 
         return StatusCode.Success

--- a/python/escore/core_ops/links/skip_chain_if_present.py
+++ b/python/escore/core_ops/links/skip_chain_if_present.py
@@ -1,0 +1,82 @@
+"""Project: Eskapade - A python-based package for data analysis.
+
+Class: SkipChainIfPresent
+
+Created: 2016/11/08
+
+Description:
+    Algorithm to skip to the Chain if requested dataset is already present
+
+Authors:
+    ING Wholesale Banking Advanced Analytics group
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted according to the terms listed in the file
+LICENSE.
+"""
+
+from escore import process_manager, DataStore, Link, StatusCode
+
+
+class SkipChainIfPresent(Link):
+    """Sends a SkipChain enums.StatusCode signal when a requested dataset is present.
+
+    This signal causes that the Processs Manager to step immediately to the next Chain.
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize link instance.
+
+        :param str name: name of link
+        :param list collection_set: datastore keys holding the datasets to be checked. If all of these are present,
+                                    the chain is skipped.
+        :param bool check_at_initialize: if false, perform dataset present check at execute. Default is true.
+        :param bool assert_len: assert that each collection has a length greatet than zero. Default is true.
+        :param tuple assert_type: types to assert for each object. Default is ().
+        """
+        Link.__init__(self, kwargs.pop('name', 'SkipChainIfPresent'))
+
+        # process keyword arguments
+        self._process_kwargs(kwargs, collection_set=[], check_at_initialize=True, assert_len=True, assert_type=())
+        self.check_extra_kwargs(kwargs)
+
+    def initialize(self):
+        """Initialize the link."""
+        if self.check_at_initialize:
+            return self.check_collection_set()
+
+        return StatusCode.Success
+
+    def execute(self):
+        """Execute the link.
+
+        Skip to the next Chain if all of the input collections are present.
+        """
+        if not self.check_at_initialize:
+            return self.check_collection_set()
+
+        return StatusCode.Success
+
+    def check_collection_set(self):
+        """Check existence of collections in the datastore, and check that they are all present.
+
+        Collections need to be both present and not empty.
+
+        - For pandas dataframes the additional option 'skip_chain_when_key_not_in_ds' exists. Meaning,
+          skip the chain as well if the dataframe is not present in the datastore.
+        """
+        # check if collection names are present in datastore
+        ds = process_manager.service(DataStore)
+
+        present = []
+        for k in self.collection_set:
+            try:
+                ds.get(k, assert_len=self.assert_len, assert_type=self.assert_type, assert_in=True)
+                present.append(True)
+            except:
+                present.append(False)
+
+        if len(present)>0 and all(present):
+            return StatusCode.SkipChain
+
+        return StatusCode.Success

--- a/python/escore/logger/_logging.py
+++ b/python/escore/logger/_logging.py
@@ -109,7 +109,15 @@ class LogPublisher(logging.getLoggerClass()):
 
         :param handler: The log record handler.
         """
-        self.addHandler(handler)
+        # make sure we do not add duplicate handlers
+        handler_exists = False
+        if len(self.handlers) > 0:
+            for hdlr in self.handlers:
+                if isinstance(handler, type(hdlr)):
+                    handler_exists = True
+                    break
+        if not handler_exists:
+            self.addHandler(handler)
 
     def remove_handler(self, handler: logging.StreamHandler):
         """Remove a log record handler.
@@ -154,9 +162,6 @@ class LogPublisher(logging.getLoggerClass()):
 # Set LogPublisher to be the logger class.
 logging.setLoggerClass(LogPublisher)
 
-# The global application publisher. There should be only one.
-global_log_publisher = logging.getLogger('eskapade')
-
 
 # Handlers
 class ConsoleHandler(logging.StreamHandler):
@@ -179,6 +184,15 @@ class ConsoleErrHandler(logging.StreamHandler):
         """Initialize the ConsoleHandler object."""
         super().__init__(sys.stderr)
         self.setLevel(LogLevel.ERROR)
+
+
+# The global application publisher. There should be only one.
+global_log_publisher = logging.getLogger('eskapade')
+# initialize to info. can be overwritten later.
+global_log_publisher.log_level = LogLevel.INFO
+# publisher takes care that same handler is never added twice
+global_log_publisher.add_handler(ConsoleHandler())
+global_log_publisher.add_handler(ConsoleErrHandler())
 
 
 class Logger(object):

--- a/python/escore/tutorials/esk112_parallel_fork_demo.py
+++ b/python/escore/tutorials/esk112_parallel_fork_demo.py
@@ -1,0 +1,56 @@
+"""Project: Eskapade - A python-based package for data analysis.
+
+Macro: esk112_parallel_fork_demo
+
+Created: 2018-12-26
+
+Description:
+    Macro does ...(fill in short description here)
+
+Authors:
+    Your name(s) here
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted according to the terms listed in the file
+LICENSE.
+"""
+
+from escore import process_manager, Chain, ConfigObject, core_ops
+from escore.logger import Logger, LogLevel
+
+
+
+logger = Logger()
+logger.debug('Now parsing configuration file esk112_parallel_fork_demo.')
+
+# --- minimal analysis information
+
+settings = process_manager.service(ConfigObject)
+settings['analysisName'] = 'esk112_parallel_fork_demo'
+settings['version'] = 0
+
+# --- now set up the chains and links
+
+ch = Chain('Start')
+ch.n_fork = 100
+fe = core_ops.ForkExample()
+fe.store_key = 'forkstoredemo'
+fe.logger.log_level = LogLevel.DEBUG
+ch.add(fe)
+
+dc = core_ops.ForkDataCollector()
+dc.keys = [{'key_ds': fe.store_key, 'func': len}]
+dc.logger.log_level = LogLevel.DEBUG
+ch.add(dc)
+
+ch = Chain('Overview')
+link = core_ops.PrintDs()
+link.keys = [fe.store_key]
+ch.add(link)
+
+logger.debug('Done parsing configuration file esk112_parallel_fork_demo.')
+
+
+if __name__ == "__main__":
+    import escore
+    escore.eskapade_run()

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ from setuptools import setup
 
 NAME = 'Eskapade-Core'
 
-MAJOR = 0
-REVISION = 9
-PATCH = 4
+MAJOR = 1
+REVISION = 0
+PATCH = 0
 DEV = False
 
 # NOTE: also update version at: README.rst


### PR DESCRIPTION
- Logger is now always initialized, so output is visible!
- added check that logger handlers cannot be added multiple times to logger.
- Bugfix: only execute macro in escore.eskapade_run() if properly settings properly filled
- added __main__ function to every newly generated macro, so macros can now be run standalone.
- Updated versions to v1.0.0 throughout repo.
- Added release notes for Eskapade-Core v1.0.0

Can you make tag v1.0.0? Thanks!